### PR TITLE
adds !codigo command to show users how to format their code on discord

### DIFF
--- a/src/commands/codigo.js
+++ b/src/commands/codigo.js
@@ -1,0 +1,30 @@
+const categories = require('../userCategory');
+
+module.exports = {
+  run(client, message) {
+    const answer =
+      String.raw`
+      Formate seu código:
+      \`\`\`js
+          CÓDIGO AQUI
+      \`\`\`
+Troque 'js' por sua linguagem
+      `;
+
+    const example = "\```js\n\
+const foo = 10;\
+    ```\
+    ";
+
+    message.channel.send(`${answer}\n${example}`);
+  },
+
+  get command() {
+    return {
+      name: 'codigo',
+      category: categories.USER,
+      description: 'Irá mostrar como formatar um bloco de código.',
+      usage: 'codigo',
+    };
+  },
+};


### PR DESCRIPTION
Usuários mandam snippets de código em todo discord de programação.

Comando mostra de forma rápida como formatar o código dentro do discord.

Como usar: !codigo

Resultado:
![bot-codigo-command-preview](https://user-images.githubusercontent.com/17282221/59959073-d0231780-9486-11e9-880d-7dc97b71978b.png)
