### PR TITLE
Add !mute & !silent

### DIFF
--- a/src/Commands/Anunciar.ts
+++ b/src/Commands/Anunciar.ts
@@ -17,7 +17,7 @@ export default class Anunciar extends Command {
     return ":x: Como usar: `!anunciar <mensagem>`"
   }
 
-  public validate(args: string[]): void | never {
+  public validate({ args }: Context): void | never {
     if (args.length === 0) {
       throw new InvalidArgsException(this.help())
     }

--- a/src/Commands/Chat.ts
+++ b/src/Commands/Chat.ts
@@ -22,14 +22,14 @@ export default class Chat extends Command {
     return ":x: Como usar: `!chat <on/off>`"
   }
 
-  public validate(args: string[]): void | never {
-    if (args.length === 0 || (args[0] !== "on" && args[0] !== "off")) {
+  public validate({ arg }: Context): void | never {
+    if (arg !== "on" && arg !== "off") {
       throw new InvalidArgsException(this.help())
     }
   }
 
-  public async run({ args, send, setRolePermissions }: Context): Promise<void> {
-    const SEND_MESSAGES = args[0] === "on"
+  public async run({ arg, send, setRolePermissions }: Context): Promise<void> {
+    const SEND_MESSAGES = arg === "on"
 
     await setRolePermissions("@everyone", { SEND_MESSAGES })
 

--- a/src/Commands/Clear.ts
+++ b/src/Commands/Clear.ts
@@ -15,12 +15,12 @@ export default class Clear extends Command {
     return character.split("").every((c) => c >= "0" && c <= "9")
   }
 
-  public validate(args: string[]): void | never {
-    if (args.length === 0 || !this.isDigit(args[0])) {
+  public validate({ arg }: Context): void | never {
+    if (this.isDigit(arg)) {
       throw new InvalidArgsException(this.help())
     }
 
-    const messagesToDelete = parseInt(args[0])
+    const messagesToDelete = parseInt(arg)
     if (messagesToDelete < 1 || messagesToDelete > 100) {
       throw new InvalidArgsException(this.help())
     }
@@ -30,9 +30,9 @@ export default class Clear extends Command {
     return ":x: Como usar: `!clear <quantidade_mensagens(min:1|max:100)>`"
   }
 
-  public async run({ args, deleteChannelMessages }: Context): Promise<void> {
+  public async run({ arg, deleteChannelMessages }: Context): Promise<void> {
     const userMessage = 1
-    const limit = parseInt(args[0]) + userMessage
+    const limit = parseInt(arg) + userMessage
 
     await deleteChannelMessages({ limit })
   }

--- a/src/Commands/Color.ts
+++ b/src/Commands/Color.ts
@@ -26,15 +26,18 @@ export default class Color extends Command {
     return parseInt(value, 16).toString(16) === value.toLowerCase()
   }
 
-  public validate(args: string[]): void | never {
-    if (args.length === 0 || !this.isHex(args[0])) {
+  public validate({ arg }: Context): void | never {
+    if (!this.isHex(arg)) {
       throw new InvalidArgsException(this.help())
     }
   }
 
-  public async run({ args, send, user, createRole }: Context): Promise<void> {
-    const [color] = args
-
+  public async run({
+    arg: color,
+    send,
+    user,
+    createRole
+  }: Context): Promise<void> {
     const roleName = /.+#\d{4}/i
 
     if (!user.hasRole(roleName)) {

--- a/src/Commands/Descrever.ts
+++ b/src/Commands/Descrever.ts
@@ -12,14 +12,14 @@ export default class Descrever extends Command {
     return ":x: Como usar: `!descrever <comando>`"
   }
 
-  public validate(args: string[]): void | never {
-    if (args.length === 0) {
+  public validate({ arg }: Context): void | never {
+    if (!arg) {
       throw new InvalidArgsException(this.help())
     }
   }
 
-  public async run({ args, send }: Context): Promise<void> {
-    const command = Ioc.use<Command>(args[0])
+  public async run({ arg, send }: Context): Promise<void> {
+    const command = Ioc.use<Command>(arg)
 
     await send(command.description)
   }

--- a/src/Commands/Mute.ts
+++ b/src/Commands/Mute.ts
@@ -30,7 +30,7 @@ export default class Mute extends Command {
     getMentionedUsers,
     textChannels
   }: Context): Promise<void> {
-    const userToMute = getMentionedUsers().first()
+    const [userToMute] = getMentionedUsers()
 
     userToMute.addRole(process.env.MUTED_ROLE!)
 

--- a/src/Commands/Mute.ts
+++ b/src/Commands/Mute.ts
@@ -1,0 +1,64 @@
+import { RichEmbed } from "discord.js"
+
+import Command from "@core/Contracts/Command"
+import Context from "@core/Contracts/Context"
+import InvalidArgsException from "@core/Exceptions/InvalidArgs"
+
+export default class Mute extends Command {
+  public get description() {
+    return "Muta um usuário"
+  }
+
+  public get permissions(): string[] {
+    return ["BAN_MEMBERS"]
+  }
+
+  public help(): string {
+    return ":x: Como usar: `!mute <nick> <motivo>`"
+  }
+
+  public validate({ args, hasMentionedUsers }: Context): void | never {
+    if (!hasMentionedUsers() || args.length <= 2) {
+      throw new InvalidArgsException(this.help())
+    }
+  }
+
+  public async run({
+    args,
+    send,
+    user,
+    getMentionedUsers,
+    textChannels
+  }: Context): Promise<void> {
+    const userToMute = getMentionedUsers().first()
+
+    userToMute.addRole(process.env.MUTED_ROLE!)
+
+    const muteReason = args.join(" ").trim()
+
+    const infoEmbed = new RichEmbed()
+      .setTitle("``🚔`` » Punição")
+      .addField("``👤`` **Usuário mutado:**", userToMute.user, true)
+      .addField("``👮`` **Mutado por:**", user.name(), true)
+      .addField("``📄`` **Tipo:**", "Mute", true)
+      .addField("``📣`` **Motivo:**", muteReason, true)
+      .setThumbnail(userToMute.user.avatarURL)
+      .setColor("#8146DC")
+      .setFooter(
+        "2019 © He4rt Developers",
+        "https://heartdevs.com/wp-content/uploads/2018/12/logo.png"
+      )
+      .setTimestamp()
+
+    await send(
+      new RichEmbed()
+        .setTitle("``✅`` Usuário mutado com sucesso.")
+        .addField("**Motivo: **", muteReason, true)
+    )
+
+    await Promise.all([
+      userToMute.send("Você foi mutado, mais informações abaixo.", infoEmbed),
+      textChannels.get(process.env.PUNISHMENT_CHAT!)!.send(infoEmbed)
+    ])
+  }
+}

--- a/src/Commands/Reuniao.ts
+++ b/src/Commands/Reuniao.ts
@@ -1,0 +1,52 @@
+import Command from "@core/Contracts/Command"
+import Context from "@core/Contracts/Context"
+import InvalidArgsException from "@core/Exceptions/InvalidArgs"
+
+export default class Reuniao extends Command {
+  public get description() {
+    return "Coloca o servidor em modo reunião."
+  }
+
+  public get roles(): string[] {
+    return [process.env.ADMIN_ROLE!]
+  }
+
+  public get roleValidationMessages() {
+    return {
+      [process.env
+        .ADMIN_ROLE!]: "Apenas administradores podem usar esse comando"
+    }
+  }
+
+  public help(): string {
+    return ":x: Como usar: `!reuniao <on|off>`"
+  }
+
+  public validate({ arg }: Context): void | never {
+    const states = {
+      on: 1,
+      off: 2
+    }
+
+    if (!(arg in states)) {
+      throw new InvalidArgsException(this.help())
+    }
+  }
+
+  public async run({ client, arg }: Context): Promise<void> {
+    client.channels
+      .filter(
+        (channel) =>
+          !/Reunião/i.test((channel as any).name) &&
+          !/My Bot Server/i.test((channel as any).name)
+      )
+      .forEach((channel) =>
+        (channel as any).replacePermissionOverwrites({
+          overwrites: client.users.map((user) => ({
+            id: user.id,
+            denied: arg === "on" ? ["VIEW_CHANNEL"] : []
+          }))
+        })
+      )
+  }
+}

--- a/src/Commands/Say.ts
+++ b/src/Commands/Say.ts
@@ -22,7 +22,7 @@ export default class Say extends Command {
     return ":x: Como usar: `!say <message>`"
   }
 
-  public validate(args: string[]): void | never {
+  public validate({ args }: Context): void | never {
     if (args.length === 0) {
       throw new InvalidArgsException(this.help())
     }

--- a/src/Commands/SayAll.ts
+++ b/src/Commands/SayAll.ts
@@ -22,7 +22,7 @@ export default class SayAll extends Command {
     return ":x: Como usar: `!sayall <message>`"
   }
 
-  public validate(args: string[]): void | never {
+  public validate({ args }: Context): void | never {
     if (args.length === 0) {
       throw new InvalidArgsException(this.help())
     }

--- a/src/Commands/Silent.ts
+++ b/src/Commands/Silent.ts
@@ -1,0 +1,30 @@
+import Command from "@core/Contracts/Command"
+import Context from "@core/Contracts/Context"
+
+export default class Silent extends Command {
+  public get description() {
+    return "Desativa/ativa mensagens da equipe"
+  }
+
+  public help(): string {
+    return "Como usar: `!silent`"
+  }
+
+  public async run({ send, user }: Context): Promise<void> {
+    const role = process.env.NOTIFY_ROLE!
+
+    const hasRole = user.hasRole(role)
+
+    if (hasRole) {
+      await user.removeRole(role)
+    } else {
+      await user.addRole(role)
+    }
+
+    await send(
+      hasRole
+        ? "Você receberá mensagens da equipe"
+        : "Você não receberá mensagens da equipe"
+    )
+  }
+}

--- a/src/Commands/Traduzir.ts
+++ b/src/Commands/Traduzir.ts
@@ -12,7 +12,7 @@ export default class Traduzir extends Command {
     return ":x: Como usar: `!traduzir <language(exemplo: en)> <text>`"
   }
 
-  public validate(args: string[]): void | never {
+  public validate({ args }: Context): void | never {
     if (args.length < 2) {
       throw new InvalidArgsException(this.help())
     }

--- a/src/Core/Contracts/Command.ts
+++ b/src/Core/Contracts/Command.ts
@@ -30,7 +30,7 @@ export default abstract class Command {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  public validate(args: string[]): void | never {}
+  public validate(context: Context): void | never {}
 
   public abstract help(): string
 

--- a/src/Core/Contracts/Context.ts
+++ b/src/Core/Contracts/Context.ts
@@ -19,7 +19,6 @@ import {
 export default interface Context {
   client: Client
   message: Message
-  members: Collection<Snowflake, GuildMember>
   send(
     content?: StringResolvable,
     options?: MessageOptions | RichEmbed | Attachment
@@ -53,6 +52,6 @@ export default interface Context {
   deleteChannelMessages(
     options?: ChannelLogsQueryOptions
   ): Promise<Collection<string, Message>>
-  getMentionedUsers: () => Collection<string, GuildMember>
+  getMentionedUsers: () => GuildMember[]
   hasMentionedUsers: () => boolean
 }

--- a/src/Core/Contracts/Context.ts
+++ b/src/Core/Contracts/Context.ts
@@ -33,6 +33,7 @@ export default interface Context {
   ): Promise<Message | Message[]>
   reply(options?: MessageOptions): Promise<Message | Message[]>
   command: string
+  arg: string
   args: string[]
   user: GuildMember & {
     name(): string
@@ -52,4 +53,6 @@ export default interface Context {
   deleteChannelMessages(
     options?: ChannelLogsQueryOptions
   ): Promise<Collection<string, Message>>
+  getMentionedUsers: () => Collection<string, GuildMember>
+  hasMentionedUsers: () => boolean
 }

--- a/src/Core/Transformers/Message.ts
+++ b/src/Core/Transformers/Message.ts
@@ -24,9 +24,8 @@ export default class MessageTransformer {
       client,
       message,
       command,
-      arg: args.length > 0 ? args[0] : "",
+      arg: args[0] || "",
       args,
-      members: {} as any /* client.guilds.get(process.env.GUILD_ID!)!.members */,
       send: message.channel.send.bind(message.channel),
       reply: message.reply.bind(message),
       user: {
@@ -35,7 +34,7 @@ export default class MessageTransformer {
         role: (name: string | RegExp): Role =>
           message.member.roles.find((r) => new RegExp(name).test(r.name)),
         hasRole: (name: string | RegExp): boolean =>
-          !!message.member.roles.find((r) => new RegExp(name).test(r.name))
+          message.member.roles.some((r) => new RegExp(name).test(r.name))
       } as any /* change this */,
       textChannels: client.channels as Collection<string, TextChannel>,
       voiceChannels: client.channels as Collection<string, VoiceChannel>,
@@ -55,8 +54,8 @@ export default class MessageTransformer {
         message.channel
           .fetchMessages(options)
           .then((messages) => message.channel.bulkDelete(messages)),
-      getMentionedUsers: () => message.mentions.members,
-      hasMentionedUsers: () => !!message.mentions.members.first()
+      getMentionedUsers: () => message.mentions.members.array(),
+      hasMentionedUsers: () => Boolean(message.mentions.members.first())
     }
   }
 }

--- a/src/Core/Transformers/Message.ts
+++ b/src/Core/Transformers/Message.ts
@@ -24,8 +24,9 @@ export default class MessageTransformer {
       client,
       message,
       command,
+      arg: args.length > 0 ? args[0] : "",
       args,
-      members: client.guilds.get(process.env.GUILD_ID!)!.members,
+      members: {} as any /* client.guilds.get(process.env.GUILD_ID!)!.members */,
       send: message.channel.send.bind(message.channel),
       reply: message.reply.bind(message),
       user: {
@@ -53,7 +54,9 @@ export default class MessageTransformer {
       deleteChannelMessages: (options?: ChannelLogsQueryOptions) =>
         message.channel
           .fetchMessages(options)
-          .then((messages) => message.channel.bulkDelete(messages))
+          .then((messages) => message.channel.bulkDelete(messages)),
+      getMentionedUsers: () => message.mentions.members,
+      hasMentionedUsers: () => !!message.mentions.members.first()
     }
   }
 }

--- a/src/Core/Validators/Role.ts
+++ b/src/Core/Validators/Role.ts
@@ -46,12 +46,8 @@ export default class RoleValidator implements Validator {
   }
 
   public async validate(ctx: Context, command: Command): Promise<void> {
-    if (command.roles.length > 0) {
-      this.validateRoles(ctx, command)
-    }
-    if (command.permissions.length > 0) {
-      this.validatePermissions(ctx, command)
-    }
+    this.validateRoles(ctx, command)
+    this.validatePermissions(ctx, command)
 
     if (this._failed && this._messages.length === 0) {
       this._messages.push("Você não está autorizado a usar esse comando :(")

--- a/src/Events/Message.ts
+++ b/src/Events/Message.ts
@@ -35,7 +35,7 @@ export default class Message extends Event {
         return
       }
 
-      command.validate(context.args)
+      command.validate(context)
       await command.run(context)
     } catch (exception) {
       if (process.env.DEBUG) {


### PR DESCRIPTION
Add two comands: !mute & !silent
Add `arg` to context object, which can be used instead of `args[0]` when the command takes only one argument

Example:

- Before
```ts
public async run({args}: Context): Promise<void> {
  foo(args[0])
  ...
}
```
- Now
```ts
public async run({arg}: Context): Promise<void> {
  foo(arg)
  ...
}
```

`args` can still be used when the command takes more than one argument(more than one word separated by spaces)