### PR TITLE
Refactor: Stop using classes for commands

### DIFF
--- a/src/Commands/Anunciar.ts
+++ b/src/Commands/Anunciar.ts
@@ -1,29 +1,18 @@
 import { RichEmbed } from "discord.js"
 
 import Command from "@core/Contracts/Command"
-import Context from "@core/Contracts/Context"
 import InvalidArgsException from "@core/Exceptions/InvalidArgs"
 
-export default class Anunciar extends Command {
-  public get description() {
-    return "Faz o bot anunciar algo no chat usando everyone"
-  }
-
-  public get permissions(): string[] {
-    return ["MANAGE_GUILD"]
-  }
-
-  public help(): string {
-    return ":x: Como usar: `!anunciar <mensagem>`"
-  }
-
-  public validate({ args }: Context): void | never {
+const command = Command({
+  description: "Faz o bot anunciar algo no chat usando everyone",
+  permissions: ["MANAGE_GUILD"],
+  help: ":x: Como usar: `!anunciar <mensagem>`",
+  validate: async ({ args }) => {
     if (args.length === 0) {
-      throw new InvalidArgsException(this.help())
+      throw new InvalidArgsException(command.help)
     }
-  }
-
-  public async run({ args, send }: Context): Promise<void> {
+  },
+  run: async ({ args, send }) => {
     const message = args.join(" ").trim()
 
     const announcement = new RichEmbed()
@@ -37,5 +26,6 @@ export default class Anunciar extends Command {
       .setTimestamp()
 
     await send("@everyone", announcement)
-  }
-}
+  },
+})
+export default command

--- a/src/Commands/Chat.ts
+++ b/src/Commands/Chat.ts
@@ -1,34 +1,20 @@
 import env from "@/env"
 import Command from "@core/Contracts/Command"
-import Context from "@core/Contracts/Context"
 import InvalidArgsException from "@core/Exceptions/InvalidArgs"
 
-export default class Chat extends Command {
-  public get description() {
-    return "Ao usar o comando irá ativar ou desativar o chat"
-  }
-
-  public get roles(): string[] {
-    return [env.ADMIN_ROLE]
-  }
-
-  public get roleValidationMessages() {
-    return {
-      [env.ADMIN_ROLE]: "Apenas administradores podem usar esse comando",
-    }
-  }
-
-  public help(): string {
-    return ":x: Como usar: `!chat <on/off>`"
-  }
-
-  public validate({ arg }: Context): void | never {
+const command = Command({
+  description: "Ao usar o comando irá ativar ou desativar o chat",
+  roles: [env.ADMIN_ROLE],
+  roleValidationMessages: {
+    [env.ADMIN_ROLE]: "Apenas administradores podem usar esse comando",
+  },
+  help: ":x: Como usar: `!chat <on/off>`",
+  validate: async ({ arg }) => {
     if (arg !== "on" && arg !== "off") {
-      throw new InvalidArgsException(this.help())
+      throw new InvalidArgsException(command.help)
     }
-  }
-
-  public async run({ arg, send, setRolePermissions }: Context): Promise<void> {
+  },
+  run: async ({ arg, send, setRolePermissions }) => {
     const SEND_MESSAGES = arg === "on"
 
     await setRolePermissions("@everyone", { SEND_MESSAGES })
@@ -38,5 +24,6 @@ export default class Chat extends Command {
         ? "``❗`` Este canal foi aberto."
         : "``❗`` Este canal foi pausado."
     )
-  }
-}
+  },
+})
+export default command

--- a/src/Commands/Clear.ts
+++ b/src/Commands/Clear.ts
@@ -1,39 +1,28 @@
 import Command from "@core/Contracts/Command"
-import Context from "@core/Contracts/Context"
 import InvalidArgsException from "@core/Exceptions/InvalidArgs"
 
-export default class Clear extends Command {
-  public get description() {
-    return "Limpa o chat"
-  }
-
-  public get permissions(): string[] {
-    return ["MANAGE_GUILD"]
-  }
-
-  private isDigit(character: string): boolean {
-    return character.split("").every((c) => c >= "0" && c <= "9")
-  }
-
-  public validate({ arg }: Context): void | never {
-    if (this.isDigit(arg)) {
-      throw new InvalidArgsException(this.help())
+const isDigit = (character: string): boolean => {
+  return character.split("").every((c) => c >= "0" && c <= "9")
+}
+const command = Command({
+  description: "Limpa o chat",
+  permissions: ["MANAGE_GUILD"],
+  validate: async ({ arg }) => {
+    if (isDigit(arg)) {
+      throw new InvalidArgsException(command.help)
     }
 
     const messagesToDelete = parseInt(arg)
     if (messagesToDelete < 1 || messagesToDelete > 100) {
-      throw new InvalidArgsException(this.help())
+      throw new InvalidArgsException(command.help)
     }
-  }
-
-  public help(): string {
-    return ":x: Como usar: `!clear <quantidade_mensagens(min:1|max:100)>`"
-  }
-
-  public async run({ arg, deleteChannelMessages }: Context): Promise<void> {
+  },
+  help: ":x: Como usar: `!clear <quantidade_mensagens(min:1|max:100)>`",
+  run: async ({ arg, deleteChannelMessages }) => {
     const userMessage = 1
     const limit = parseInt(arg) + userMessage
 
     await deleteChannelMessages({ limit })
-  }
-}
+  },
+})
+export default command

--- a/src/Commands/Codigo.ts
+++ b/src/Commands/Codigo.ts
@@ -1,19 +1,13 @@
 import Command from "@core/Contracts/Command"
-import Context from "@core/Contracts/Context"
 
-export default class Codigo extends Command {
-  public get description() {
-    return "Mostra como formatar o código no chat."
-  }
-
-  public help(): string {
-    return ":x: Como usar: `!codigo`"
-  }
-
-  public async run({ send }: Context): Promise<void> {
+const command = Command({
+  description: "Mostra como formatar o código no chat.",
+  help: ":x: Como usar: `!codigo`",
+  run: async ({ send }) => {
     const answer =
       "Formate seu código:\n\\`\\`\\`js\n    CODIGO AQUI\n\\`\\`\\`\nTroque 'js' por sua lang \n```js\n const foo = 10\n```"
 
     await send(answer)
-  }
-}
+  },
+})
+export default command

--- a/src/Commands/Color.ts
+++ b/src/Commands/Color.ts
@@ -1,44 +1,24 @@
 import env from "@/env"
 import Command from "@core/Contracts/Command"
-import Context from "@core/Contracts/Context"
 import InvalidArgsException from "@core/Exceptions/InvalidArgs"
 
-export default class Color extends Command {
-  public get description() {
-    return "Troca a cor do seu nick"
-  }
+const isHex = (value: string): boolean => {
+  return parseInt(value, 16).toString(16) === value.toLowerCase()
+}
 
-  public get roles(): string[] {
-    return [env.DONATOR_ROLE]
-  }
-
-  public get roleValidationMessages() {
-    return {
-      [env.DONATOR_ROLE]:
-        "Esse comando está disponivel apenas para apoiadores!",
+const command = Command({
+  description: "Troca a cor do seu nick",
+  roles: [env.DONATOR_ROLE],
+  roleValidationMessages: {
+    [env.DONATOR_ROLE]: "Esse comando está disponivel apenas para apoiadores!",
+  },
+  help: ":x: Como usar: `!color <hex>` (código hexadecimal da cor)",
+  validate: async ({ arg }) => {
+    if (!isHex(arg)) {
+      throw new InvalidArgsException(command.help)
     }
-  }
-
-  public help(): string {
-    return ":x: Como usar: `!color <hex>` (código hexadecimal da cor)"
-  }
-
-  private isHex(value: string): boolean {
-    return parseInt(value, 16).toString(16) === value.toLowerCase()
-  }
-
-  public validate({ arg }: Context): void | never {
-    if (!this.isHex(arg)) {
-      throw new InvalidArgsException(this.help())
-    }
-  }
-
-  public async run({
-    arg: color,
-    send,
-    user,
-    createRole,
-  }: Context): Promise<void> {
+  },
+  run: async ({ arg: color, send, user, createRole }) => {
     const roleName = /.+#\d{4}/i
 
     if (!user.hasRole(roleName)) {
@@ -66,5 +46,6 @@ export default class Color extends Command {
 
     const newRole = await role.setColor(color)
     await send(`Cor atualizada com sucesso! hex(${newRole.color})`)
-  }
-}
+  },
+})
+export default command

--- a/src/Commands/Descrever.ts
+++ b/src/Commands/Descrever.ts
@@ -1,26 +1,19 @@
 import Command from "@core/Contracts/Command"
-import Context from "@core/Contracts/Context"
 import InvalidArgsException from "@core/Exceptions/InvalidArgs"
 import Ioc from "@core/IoC/Ioc"
 
-export default class Descrever extends Command {
-  public get description() {
-    return "Mostra a descrição de um comando."
-  }
-
-  public help(): string {
-    return ":x: Como usar: `!descrever <comando>`"
-  }
-
-  public validate({ arg }: Context): void | never {
+const command = Command({
+  description: "Mostra a descrição de um comando.",
+  help: ":x: Como usar: `!descrever <comando>`",
+  validate: async ({ arg }) => {
     if (!arg) {
-      throw new InvalidArgsException(this.help())
+      throw new InvalidArgsException(command.help)
     }
-  }
-
-  public async run({ arg, send }: Context): Promise<void> {
+  },
+  run: async ({ arg, send }) => {
     const command = Ioc.use<Command>(arg)
 
     await send(command.description)
-  }
-}
+  },
+})
+export default command

--- a/src/Commands/Help.ts
+++ b/src/Commands/Help.ts
@@ -1,19 +1,13 @@
 import Ioc from "@core/IoC/Ioc"
 import Command from "@core/Contracts/Command"
-import Context from "@core/Contracts/Context"
 
-export default class Help extends Command {
-  public get description() {
-    return "Exibe a lista de comandos disponíveis."
-  }
-
-  public help(): string {
-    return ":x: Como usar: `!help`"
-  }
-
-  public async run({ send }: Context): Promise<void> {
+const command = Command({
+  description: "Exibe a lista de comandos disponíveis.",
+  help: ":x: Como usar: `!help`",
+  run: async ({ send }) => {
     const commandList = Ioc.use<string[]>("Commands")
 
     await send(`Comandos disponíveis: ${commandList}`)
-  }
-}
+  },
+})
+export default command

--- a/src/Commands/Mute.ts
+++ b/src/Commands/Mute.ts
@@ -2,35 +2,18 @@ import env from "@/env"
 import { RichEmbed } from "discord.js"
 
 import Command from "@core/Contracts/Command"
-import Context from "@core/Contracts/Context"
 import InvalidArgsException from "@core/Exceptions/InvalidArgs"
 
-export default class Mute extends Command {
-  public get description() {
-    return "Muta um usuário"
-  }
-
-  public get permissions(): string[] {
-    return ["BAN_MEMBERS"]
-  }
-
-  public help(): string {
-    return ":x: Como usar: `!mute <nick> <motivo>`"
-  }
-
-  public validate({ args, hasMentionedUsers }: Context): void | never {
+const command = Command({
+  description: "Muta um usuário",
+  permissions: ["BAN_MEMBERS"],
+  help: ":x: Como usar: `!mute <nick> <motivo>`",
+  validate: async ({ args, hasMentionedUsers }) => {
     if (!hasMentionedUsers() || args.length <= 2) {
-      throw new InvalidArgsException(this.help())
+      throw new InvalidArgsException(command.help)
     }
-  }
-
-  public async run({
-    args,
-    send,
-    user,
-    getMentionedUsers,
-    textChannels,
-  }: Context): Promise<void> {
+  },
+  run: async ({ args, send, user, getMentionedUsers, textChannels }) => {
     const [userToMute] = getMentionedUsers()
 
     userToMute.addRole(env.MUTED_ROLE)
@@ -61,5 +44,6 @@ export default class Mute extends Command {
       userToMute.send("Você foi mutado, mais informações abaixo.", infoEmbed),
       textChannels.get(env.PUNISHMENT_CHAT)!.send(infoEmbed),
     ])
-  }
-}
+  },
+})
+export default command

--- a/src/Commands/Ping.ts
+++ b/src/Commands/Ping.ts
@@ -1,16 +1,10 @@
 import Command from "@core/Contracts/Command"
-import Context from "@core/Contracts/Context"
 
-export default class Ping extends Command {
-  public get description() {
-    return "Mostra a latência do bot"
-  }
-
-  public help(): string {
-    return ":x: Como usar: `!ping`"
-  }
-
-  public async run({ send, client }: Context): Promise<void> {
+const command = Command({
+  description: "Mostra a latência do bot",
+  help: ":x: Como usar: `!ping`",
+  run: async ({ send, client }) => {
     await send(`\`\`📡\`\` Latência da API: ${Math.round(client.ping)}ms.`)
-  }
-}
+  },
+})
+export default command

--- a/src/Commands/Reuniao.ts
+++ b/src/Commands/Reuniao.ts
@@ -1,39 +1,25 @@
 import env from "@/env"
 import Command from "@core/Contracts/Command"
-import Context from "@core/Contracts/Context"
 import InvalidArgsException from "@core/Exceptions/InvalidArgs"
 
-export default class Reuniao extends Command {
-  public get description() {
-    return "Coloca o servidor em modo reunião."
-  }
-
-  public get roles(): string[] {
-    return [env.ADMIN_ROLE]
-  }
-
-  public get roleValidationMessages() {
-    return {
-      [env.ADMIN_ROLE]: "Apenas administradores podem usar esse comando",
-    }
-  }
-
-  public help(): string {
-    return ":x: Como usar: `!reuniao <on|off>`"
-  }
-
-  public validate({ arg }: Context): void | never {
+const command = Command({
+  description: "Coloca o servidor em modo reunião.",
+  roles: [env.ADMIN_ROLE],
+  roleValidationMessages: {
+    [env.ADMIN_ROLE]: "Apenas administradores podem usar esse comando",
+  },
+  help: ":x: Como usar: `!reuniao <on|off>`",
+  validate: async ({ arg }) => {
     const states = {
       on: 1,
       off: 2,
     }
 
     if (!(arg in states)) {
-      throw new InvalidArgsException(this.help())
+      throw new InvalidArgsException(command.help)
     }
-  }
-
-  public async run({ client, arg }: Context): Promise<void> {
+  },
+  run: async ({ client, arg }) => {
     client.channels
       .filter(
         (channel) =>
@@ -48,5 +34,6 @@ export default class Reuniao extends Command {
           })),
         })
       )
-  }
-}
+  },
+})
+export default command

--- a/src/Commands/Rules.ts
+++ b/src/Commands/Rules.ts
@@ -1,6 +1,5 @@
 import env from "@/env"
 import Command from "@core/Contracts/Command"
-import Context from "@core/Contracts/Context"
 
 const rules = `
 <:he4rt:546395281093034015> Sejam bem-vindos ao servidor He4rt Developers! [:flag_br:]
@@ -21,20 +20,12 @@ const rules = `
 # Insistência (3º Ocorrênncia): Banimento permanente.\`\`\`
 `
 
-export default class Rules extends Command {
-  public get description() {
-    return "Envia as regras para o usuário."
-  }
-
-  public get permissions(): string[] {
-    return ["MANAGE_GUILD"]
-  }
-
-  public help(): string {
-    return ":x:Como usar: `!rules`"
-  }
-
-  public async run({ textChannels }: Context): Promise<void> {
+const command = Command({
+  description: "Envia as regras para o usuário.",
+  permissions: ["MANAGE_GUILD"],
+  help: ":x:Como usar: `!rules`",
+  run: async ({ textChannels }) => {
     await textChannels.get(env.RULES_CHAT)!.send(rules)
-  }
-}
+  },
+})
+export default command

--- a/src/Commands/Say.ts
+++ b/src/Commands/Say.ts
@@ -1,34 +1,21 @@
 import env from "@/env"
 import Command from "@core/Contracts/Command"
-import Context from "@core/Contracts/Context"
 import InvalidArgsException from "@core/Exceptions/InvalidArgs"
 
-export default class Say extends Command {
-  public get description() {
-    return "Manda uma mensagem pelo bot."
-  }
-
-  public get roles(): string[] {
-    return [env.ADMIN_ROLE]
-  }
-
-  public get roleValidationMessages() {
-    return {
-      [env.ADMIN_ROLE]: "Apenas administradores podem usar esse comando",
-    }
-  }
-
-  public help(): string {
-    return ":x: Como usar: `!say <message>`"
-  }
-
-  public validate({ args }: Context): void | never {
+const command = Command({
+  description: "Manda uma mensagem pelo bot.",
+  roles: [env.ADMIN_ROLE],
+  roleValidationMessages: {
+    [env.ADMIN_ROLE]: "Apenas administradores podem usar esse comando",
+  },
+  help: ":x: Como usar: `!say <message>`",
+  validate: async ({ args }) => {
     if (args.length === 0) {
-      throw new InvalidArgsException(this.help())
+      throw new InvalidArgsException(command.help)
     }
-  }
-
-  public async run({ args, send }: Context): Promise<void> {
+  },
+  run: async ({ args, send }) => {
     await send(args.join(" ").trim())
-  }
-}
+  },
+})
+export default command

--- a/src/Commands/SayAll.ts
+++ b/src/Commands/SayAll.ts
@@ -1,34 +1,20 @@
 import env from "@/env"
 import Command from "@core/Contracts/Command"
-import Context from "@core/Contracts/Context"
 import InvalidArgsException from "@core/Exceptions/InvalidArgs"
 
-export default class SayAll extends Command {
-  public get description() {
-    return "Manda uma mensagem pelo bot para cada usuário do servidor."
-  }
-
-  public get roles(): string[] {
-    return [env.ADMIN_ROLE]
-  }
-
-  public get roleValidationMessages() {
-    return {
-      [env.ADMIN_ROLE]: "Apenas administradores podem usar esse comando.",
-    }
-  }
-
-  public help(): string {
-    return ":x: Como usar: `!sayall <message>`"
-  }
-
-  public validate({ args }: Context): void | never {
+const command = Command({
+  description: "Manda uma mensagem pelo bot para cada usuário do servidor.",
+  roles: [env.ADMIN_ROLE],
+  roleValidationMessages: {
+    [env.ADMIN_ROLE]: "Apenas administradores podem usar esse comando.",
+  },
+  help: ":x: Como usar: `!sayall <message>`",
+  validate: async ({ args }) => {
     if (args.length === 0) {
-      throw new InvalidArgsException(this.help())
+      throw new InvalidArgsException(command.help)
     }
-  }
-
-  public async run({ args, send, members }: Context): Promise<void> {
+  },
+  run: async ({ args, send, members }) => {
     const message = args.join(" ")
 
     await send(
@@ -36,5 +22,6 @@ export default class SayAll extends Command {
     )
 
     await Promise.all(members().map((member) => member.send(message)))
-  }
-}
+  },
+})
+export default command

--- a/src/Commands/Silent.ts
+++ b/src/Commands/Silent.ts
@@ -1,17 +1,10 @@
 import env from "@/env"
 import Command from "@core/Contracts/Command"
-import Context from "@core/Contracts/Context"
 
-export default class Silent extends Command {
-  public get description() {
-    return "Desativa/ativa mensagens da equipe"
-  }
-
-  public help(): string {
-    return "Como usar: `!silent`"
-  }
-
-  public async run({ send, user }: Context): Promise<void> {
+const command = Command({
+  description: "Desativa/ativa mensagens da equipe",
+  help: "Como usar: `!silent`",
+  run: async ({ send, user }) => {
     const role = env.NOTIFY_ROLE
 
     const hasRole = user.hasRole(role)
@@ -27,5 +20,6 @@ export default class Silent extends Command {
         ? "Você receberá mensagens da equipe"
         : "Você não receberá mensagens da equipe"
     )
-  }
-}
+  },
+})
+export default command

--- a/src/Commands/Traduzir.ts
+++ b/src/Commands/Traduzir.ts
@@ -1,28 +1,21 @@
 import Command from "@core/Contracts/Command"
-import Context from "@core/Contracts/Context"
 import InvalidArgsException from "@core/Exceptions/InvalidArgs"
 import translate from "@vitalets/google-translate-api"
 
-export default class Traduzir extends Command {
-  public get description() {
-    return "Traduz uma mensagem."
-  }
-
-  public help(): string {
-    return ":x: Como usar: `!traduzir <language(exemplo: en)> <text>`"
-  }
-
-  public validate({ args }: Context): void | never {
+const command = Command({
+  description: "Traduz uma mensagem.",
+  help: ":x: Como usar: `!traduzir <language(exemplo: en)> <text>`",
+  validate: async ({ args }) => {
     if (args.length < 2) {
-      throw new InvalidArgsException(this.help())
+      throw new InvalidArgsException(command.help)
     }
-  }
-
-  public async run({ args, send }: Context): Promise<void> {
+  },
+  run: async ({ args, send }) => {
     const [to, ...message] = args
 
     const { text } = await translate(message, { to })
 
     await send(text)
-  }
-}
+  },
+})
+export default command

--- a/src/Core/Contracts/Command.ts
+++ b/src/Core/Contracts/Command.ts
@@ -1,38 +1,40 @@
 import Context from "./Context"
 
-export default abstract class Command {
-  public get description() {
-    return "Um comando que pode ser usado para interagir com o bot"
-  }
-
-  public get roles(): string[] {
-    return []
-  }
-
-  public get roleValidationMessages() {
-    return {}
-  }
-
-  public get validateAllRoles(): boolean {
-    return false
-  }
-
-  public get permissions(): string[] {
-    return []
-  }
-
-  public get permissionValidationMessages() {
-    return {}
-  }
-
-  public get validateAllPermissions(): boolean {
-    return false
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  public validate(context: Context): void | never {}
-
-  public abstract help(): string
-
-  public abstract async run(ctx: Context): Promise<void>
+interface Command {
+  readonly description: string
+  readonly roles: string[]
+  readonly roleValidationMessages: { [key: string]: string }
+  readonly validateAllRoles: boolean
+  readonly permissions: string[]
+  readonly permissionValidationMessages: { [key: string]: string }
+  readonly validateAllPermissions: boolean
+  readonly help: string
+  readonly validate: (context: Context) => Promise<void | never>
+  readonly run: (context: Context) => Promise<void>
 }
+type CommandOptions = Partial<Command> & {
+  help: Command["help"]
+  run: Command["run"]
+}
+const base = {
+  description: "Um comando que pode ser usado para interagir com o bot",
+  roles: [],
+  roleValidationMessages: [],
+  validateAllRoles: true, // TODO: should be true or false?
+  permissions: [],
+  permissionValidationMessages: {},
+  validateAllPermissions: true, // TODO: should be true or false?
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  validate: () => {},
+  help: undefined,
+  run: undefined,
+} as const
+
+const defaultObject = <T, U>(base: U, options: T): T & U =>
+  Object.fromEntries(
+    Object.keys(base).map((key) => [key, options[key] || base[key]])
+  ) as T & U
+
+const Command = (options: CommandOptions): Command =>
+  defaultObject(base, options)
+export default Command


### PR DESCRIPTION
## Why?
Right know we're using classes to implement the commands that create noise and as it's almost a consensus in the ecosystem, using class isn't a great idea adding noise and some unexpected behaviors because of how `this` binding works.